### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,6 +6,8 @@ that creates recipes mixing random ingredients.
 It pulls data from the `Open Food Facts database <https://world.openfoodfacts.org/>`_
 and offers a *simple* and *intuitive* API.
 
+Lumache has its documentation hosted on Read the Docs.
+
 Check out the :doc:`usage` section for further information, including
 how to :ref:`installation` the project.
 


### PR DESCRIPTION
added 'Lumache has its documentation hosted on Read the Docs.' as per tut